### PR TITLE
Note block CRUD endpoints proposal

### DIFF
--- a/notes/notes.proto
+++ b/notes/notes.proto
@@ -34,6 +34,8 @@ message Block {
 }
 
 service NotesService {
+    rpc GetNote(GetNoteRequest) returns (Note) {}
+
     rpc CreateNote(Note) returns (google.protobuf.Empty) {}
 
     rpc UpdateNote(UpdateNoteRequest) returns (google.protobuf.Empty) {}
@@ -45,6 +47,10 @@ service NotesService {
     rpc UpdateBlock(UpdateBlockRequest) returns (google.protobuf.Empty) {}
 
     rpc DeleteBlock(DeleteBlockRequest) returns (google.protobuf.Empty) {}
+}
+
+message GetNoteRequest {
+    string id = 1;
 }
 
 message UpdateNoteRequest {


### PR DESCRIPTION
## Description

This PR introduces new endpoints in the notes service to perform CRUD operation on blocks of a note.

## Motivation

When updating a note, you generally do it "block" by "block". In fact, when we take a look at Notion from which we drew inspiration, it's impossible to modify more than one block at a time! Therefore it seems logical to have a `UpdateBlock` endpoint to update a single block.

Same thing goes for adding and removing blocks from a note. It makes more sense to have an `AddBlock` and `RemoveBlock` rpc rather than use the `UpdateNote` endpoint which would make the request more complicated.

Finally, this will help us in the long run when we will try to allow multiple students to edit the same note at the same time because if the students don't modify the same block, all should be okay!