### PR TITLE
Recommendation definition

### DIFF
--- a/recommendations/recommendations.proto
+++ b/recommendations/recommendations.proto
@@ -1,9 +1,15 @@
 syntax = "proto3";
 
+package recommendations; 
+
 option go_package = "grpc/recommendationspb";
 
-message Recommendation {
+import "notes/notes.proto";
 
+message Recommendation {
+    string id = 1;
+    string block_id = 2;
+    repeated notes.Block blocks = 3;
 }
 
 service RecommendationsService {
@@ -11,5 +17,5 @@ service RecommendationsService {
 }
 
 message GenerateRecommendationRequest {
-    
+    string id = 1;
 }


### PR DESCRIPTION
# Description

This PR adds a definition for the protobuf's recommendation message
It imports the note.proto and uses the Block definition.

For now, it will be represented as such:

- `id` : id of the current recommendation
- `block_id` : id of the block that will receive recommendation (maybe `block_index` ?)
- `blocks` : array of block (all blocks will probably  have the same type as the block being currently recommended)
