### PR TITLE
Return updated object in `Create` and `Update` RPCs

### DIFF
--- a/noted/accounts/v1/accounts.proto
+++ b/noted/accounts/v1/accounts.proto
@@ -29,6 +29,7 @@ message CreateAccountRequest {
 }
 
 message CreateAccountResponse {
+    Account account = 1;
 }
 
 message GetAccountRequest {

--- a/noted/accounts/v1/groups.proto
+++ b/noted/accounts/v1/groups.proto
@@ -30,6 +30,7 @@ message CreateGroupRequest {
 }
 
 message CreateGroupResponse {
+    Group group = 1;
 }
 
 message DeleteGroupRequest {
@@ -46,6 +47,7 @@ message UpdateGroupRequest {
 }
 
 message UpdateGroupResponse {
+    Group group = 1;
 }
 
 message ListGroupMembersRequest {

--- a/noted/notes/v1/notes.proto
+++ b/noted/notes/v1/notes.proto
@@ -36,7 +36,7 @@ service NotesAPI {
     rpc UpdateNote(UpdateNoteRequest) returns (UpdateNoteResponse) {}
     rpc DeleteNote(DeleteNoteRequest) returns (DeleteNoteResponse) {}
     rpc ListNotes(ListNotesRequest) returns (ListNotesResponse) {}
-    rpc AddBlock(AddBlockRequest) returns (AddBlockResponse) {}
+    rpc InsertBlock(InsertBlockRequest) returns (InsertBlockResponse) {}
     rpc UpdateBlock(UpdateBlockRequest) returns (UpdateBlockResponse) {}
     rpc DeleteBlock(DeleteBlockRequest) returns (DeleteBlockResponse) {}
 }
@@ -54,6 +54,7 @@ message CreateNoteRequest {
 }
 
 message CreateNoteResponse {
+    Note note = 1;
 }
 
 message UpdateNoteRequest {
@@ -80,7 +81,7 @@ message ListNotesResponse {
     repeated Note notes = 1;
 }
 
-message AddBlockRequest {
+message InsertBlockRequest {
     // The block to append to the note.
     Block block = 1;
     // Given that a note is an array of blocks, provide the index at
@@ -88,7 +89,8 @@ message AddBlockRequest {
     uint32 index = 2;
 }
 
-message AddBlockResponse {
+message InsertBlockResponse {
+    Block block = 1;
 }
 
 message UpdateBlockRequest {
@@ -98,6 +100,7 @@ message UpdateBlockRequest {
 }
 
 message UpdateBlockResponse {
+    Block block = 1;
 }
 
 message DeleteBlockRequest {


### PR DESCRIPTION
#### Description

To prevent an API consumer from having to hit the API again for an updated representation, have the API return the updated (or created) representation as part of the response.

Contains some breaking changes.

Fixes #12

#### Changelog

- [ENHANCEMENT] Rename `NotesAPI.AddBlock` to `NotesAPI.InsertBlock`.
- [ENHANCEMENT] Return created/updated object in `Create` and `Update` RPCs.
