### PR TITLE
Attach a block to a note

### DIFF
--- a/noted/notes/v1/notes.proto
+++ b/noted/notes/v1/notes.proto
@@ -114,6 +114,8 @@ message InsertBlockRequest {
     // Given that a note is an array of blocks, provide the index at
     // which the block shall be inserted.
     uint32 index = 2;
+    //A new block need a note to be attached
+    uint32 noteId = 3;
 }
 
 message InsertBlockResponse {

--- a/noted/notes/v1/notes.proto
+++ b/noted/notes/v1/notes.proto
@@ -115,7 +115,7 @@ message InsertBlockRequest {
     // which the block shall be inserted.
     uint32 index = 2;
     //A new block need a note to be attached
-    uint32 noteId = 3;
+    uint32 note_id = 3;
 }
 
 message InsertBlockResponse {


### PR DESCRIPTION
#### Description

Added a field noteId in insertBlock in order to know at which note is attached a block 

#### Changelog

- [ENHANCEMENT]
No breaking changes because the note-service is in development and with the actual architecture (protobuff style v2) nothing is working