### PR TITLE
Add `InvitesAPI` & update `GroupsAPI` and `AccountsAPI`

### DIFF
--- a/noted/accounts/v1/accounts.proto
+++ b/noted/accounts/v1/accounts.proto
@@ -12,6 +12,9 @@ message Account {
     string email = 3;
 }
 
+// Creation, read, update and deletion of accounts.
+// Authentication using email/password and using OAuth.
+// Manages password recovery.
 service AccountsAPI {
     // Create an account using the email and password flow.
     rpc CreateAccount(CreateAccountRequest) returns (CreateAccountResponse) {}

--- a/noted/accounts/v1/accounts.proto
+++ b/noted/accounts/v1/accounts.proto
@@ -20,7 +20,7 @@ service AccountsAPI {
     rpc CreateAccount(CreateAccountRequest) returns (CreateAccountResponse) {}
     // Must be authenticated.
     rpc GetAccount(GetAccountRequest) returns (GetAccountResponse) {}
-    // Must be account owner. Can only update `acount.name`.
+    // Must be account owner. Can only update `account.name`.
     rpc UpdateAccount(UpdateAccountRequest) returns (UpdateAccountResponse) {}
     // Must be account owner.
     // TODO: Delete all associated resources (notes, transfer group ownership,

--- a/noted/accounts/v1/accounts.proto
+++ b/noted/accounts/v1/accounts.proto
@@ -12,18 +12,21 @@ message Account {
     string email = 3;
 }
 
-message Pagination {
-    int64 limit = 1;
-	int64 offset = 2;
-}
-
 service AccountsAPI {
     // Create an account using the email and password flow.
     rpc CreateAccount(CreateAccountRequest) returns (CreateAccountResponse) {}
+    // Must be authenticated.
     rpc GetAccount(GetAccountRequest) returns (GetAccountResponse) {}
+    // Must be account owner. Can only update `acount.name`.
     rpc UpdateAccount(UpdateAccountRequest) returns (UpdateAccountResponse) {}
+    // Must be account owner.
+    // TODO: Delete all associated resources (notes, transfer group ownership,
+    // etc).
     rpc DeleteAccount(DeleteAccountRequest) returns (DeleteAccountResponse) {}
-    rpc ListAccount(ListAccountRequest) returns (ListAccountResponse) {}
+    // This endpoint is not meant to be used by regular users.
+    // Only works with an internal token.
+    rpc ListAccounts(ListAccountsRequest) returns (ListAccountsResponse) {}
+
     // Authenticate using the email and password flow.
     rpc Authenticate(AuthenticateRequest) returns (AuthenticateResponse) {}
 }
@@ -72,10 +75,11 @@ message AuthenticateResponse {
     string token = 1;
 }
 
-message ListAccountRequest {
-    Pagination paginate = 1;
+message ListAccountsRequest {
+    int32 limit = 1;
+    int32 offset = 2;
 }
 
-message ListAccountResponse {
+message ListAccountsResponse {
     repeated Account accounts = 1;
 }

--- a/noted/accounts/v1/groups.proto
+++ b/noted/accounts/v1/groups.proto
@@ -60,7 +60,7 @@ service GroupsAPI {
     // Must be group member, author of the note or administrator.
     rpc RemoveGroupNote(RemoveGroupNoteRequest) returns (RemoveGroupNoteResponse) {}
     // Must be group member.
-    rpc ListGroupNotes(ListNotesInGroupRequest) returns (ListNotesInGroupResponse) {}
+    rpc ListGroupNotes(ListGroupNotesRequest) returns (ListGroupNotesResponse) {}
 
     // TODO: Next sprint -- Leave blank.
     rpc CreateFolder(CreateFolderRequest) returns (CreateFolderResponse) {}
@@ -161,7 +161,7 @@ message RemoveGroupNoteResponse {
 
 }
 
-message ListNotesInGroupRequest {
+message ListGroupNotesRequest {
     string group_id = 1;
     // (Optional) List only notes from that account.
     string author_account_id = 2;
@@ -174,7 +174,7 @@ message ListNotesInGroupRequest {
     string offset = 5;
 }
 
-message ListNotesInGroupResponse {
+message ListGroupNotesResponse {
     GroupNote notes = 1;
 }
 

--- a/noted/accounts/v1/groups.proto
+++ b/noted/accounts/v1/groups.proto
@@ -9,22 +9,60 @@ import "google/protobuf/field_mask.proto";
 message Group {
     string id = 1;
     string name = 2;
-    string owner_id = 3;   
-    repeated GroupMember members = 4;
-    string description = 5;
+    string description = 3;
 }
 
 message GroupMember {
     string account_id = 1;
+    string role = 2;
+}
+
+// NoteInGroup is the representation of a note stored wihtin the context of
+// a group (which folder it belongs to, who wrote it, its title).
+// The actual note is stored in the notes-service.
+message NoteInGroup {
+    // ID of the note within the notes-service.
+    string note_id = 1;
+    string title = 2;
+    string author_account_id = 3;
+    // Next sprint -- Leave blank.
+    string folder_id = 4;
 }
 
 service GroupsAPI {
+    // Creates a group with a single administrator member (the authenticated user).
+    // Must be authenticated.
     rpc CreateGroup(CreateGroupRequest) returns (CreateGroupResponse) {}
+    // Must be authenticated.
+    rpc GetGroup(GetGroupRequest) returns (GetGroupResponse) {}
+    // Must be group administrator.
+    // Deletes all the associated resources (members, notes).
     rpc DeleteGroup(DeleteGroupRequest) returns (DeleteGroupResponse) {}
+    // Must be group administrator.
     rpc UpdateGroup(UpdateGroupRequest) returns (UpdateGroupResponse) {}
+
+    // This endpoint is not meant to be used by regular users. Use the InvitesAPI instead.
+    // Only works with an internal token.
+    rpc AddMemberToGroup(AddMemberToGroupRequest) returns (AddMemberToGroupResponse) {}
+    // Must be group administrator.
+    rpc RemoveMemberFromGroup(RemoveMemberFromGroupRequest) returns (RemoveMemberFromGroupResponse) {}
+    // Must be group member.
     rpc ListGroupMembers(ListGroupMembersRequest) returns (ListGroupMembersResponse) {}
-    rpc JoinGroup(JoinGroupRequest) returns (JoinGroupResponse) {}
+
+    // Must be group member and author of the note.
     rpc AddNoteToGroup(AddNoteToGroupRequest) returns (AddNoteToGroupResponse) {}
+    // Must be group member. Can only update `note.title` and `note.folder_id`.
+    rpc UpdateNoteInGroup(UpdateNoteInGroupRequest) returns (UpdateNoteInGroupResponse) {}
+    // Must be group member, author of the note or administrator.
+    rpc RemoveNoteFromGroup(RemoveNoteFromGroupRequest) returns (RemoveNoteFromGroupResponse) {}
+    // Must be group member.
+    rpc ListNotesInGroup(ListNotesInGroupRequest) returns (ListNotesInGroupResponse) {}
+
+    // Next sprint -- Leave blank.
+    rpc CreateFolder(CreateFolderRequest) returns (CreateFolderReponse) {}
+    rpc RemoveFolder(RemoveFolderRequest) returns (RemoveFolderReponse) {}
+    rpc UpdateFolder(UpdateFolderRequest) returns (UpdateFolderReponse) {}
+    rpc ListFolders(ListFoldersRequest) returns (ListFoldersResponse) {}
 }
 
 message CreateGroupRequest {
@@ -36,9 +74,16 @@ message CreateGroupResponse {
     Group group = 1;
 }
 
+message GetGroupRequest {
+    string group_id = 1;
+}
+
+message GetGroupResponse {
+    Group group = 1;
+}
+
 message DeleteGroupRequest {
-    string id = 1;
-    string name = 2;
+    string group_id = 1;
 }
 
 message DeleteGroupResponse {
@@ -54,25 +99,109 @@ message UpdateGroupResponse {
 }
 
 message ListGroupMembersRequest {
-    string id = 1;
-    string name = 2;
+    string group_id = 1;
 }
 
 message ListGroupMembersResponse {
     repeated GroupMember members = 1;
 }
 
-message JoinGroupRequest {
-    string id = 1;
+message AddMemberToGroupRequest {
+    string group_id = 1;
+    string account_id = 2;
 }
 
-message JoinGroupResponse {
+message AddMemberToGroupResponse {
+}
+
+message RemoveMemberFromGroupRequest {
+    string group_id = 1;
+    string account_id = 2;
+}
+
+message RemoveMemberFromGroupResponse {
+
 }
 
 message AddNoteToGroupRequest {
-    string id = 1;
+    string group_id = 1;
+    // ID of the note within the notes-service.
     string note_id = 2;
+    string title = 3;
+    // Defaults to the authenticated user.
+    string author_account_id = 4;
+    // Next sprint -- Leave blank.
+    string folder_id = 5;
 }
 
 message AddNoteToGroupResponse {
+    NoteInGroup note = 1;
+}
+
+message UpdateNoteInGroupRequest {
+    string group_id = 1;
+    NoteInGroup note = 2;
+    google.protobuf.FieldMask update_mask = 3;
+}
+
+message UpdateNoteInGroupResponse {
+    NoteInGroup note = 1;
+}
+
+message RemoveNoteFromGroupRequest {
+    string group_id = 1;
+    string note_id = 2;
+}
+
+message RemoveNoteFromGroupResponse {
+
+}
+
+message ListNotesInGroupRequest {
+    string group_id = 1;
+    // (Optional) List only notes from that account.
+    string author_account_id = 2;
+
+    // Next sprint -- Leave blank.
+    // (Optional) List notes only from a given folder.
+    string folder_id = 3;
+
+    string limit = 4;
+    string offset = 5;
+}
+
+message ListNotesInGroupResponse {
+    NoteInGroup notes = 1;
+}
+
+message CreateFolderRequest {
+    // TODO
+}
+
+message CreateFolderReponse {
+    // TODO
+}
+
+message RemoveFolderRequest {
+    // TODO
+}
+
+message RemoveFolderReponse {
+    // TODO
+}
+
+message UpdateFolderRequest {
+    // TODO
+}
+
+message UpdateFolderReponse {
+    // TODO
+}
+
+message ListFoldersRequest {
+    // TODO
+}
+
+message ListFoldersResponse {
+    // TODO
 }

--- a/noted/accounts/v1/groups.proto
+++ b/noted/accounts/v1/groups.proto
@@ -17,10 +17,10 @@ message GroupMember {
     string role = 2;
 }
 
-// NoteInGroup is the representation of a note stored wihtin the context of
+// GroupNote is the representation of a note stored wihtin the context of
 // a group (which folder it belongs to, who wrote it, its title).
 // The actual note is stored in the notes-service.
-message NoteInGroup {
+message GroupNote {
     // ID of the note within the notes-service.
     string note_id = 1;
     string title = 2;
@@ -46,24 +46,25 @@ service GroupsAPI {
 
     // This endpoint is not meant to be used by regular users. Use the InvitesAPI instead.
     // Only works with an internal token.
-    rpc AddMemberToGroup(AddMemberToGroupRequest) returns (AddMemberToGroupResponse) {}
-    // Must be group administrator.
-    rpc RemoveMemberFromGroup(RemoveMemberFromGroupRequest) returns (RemoveMemberFromGroupResponse) {}
+    rpc AddGroupMember(AddGroupMemberRequest) returns (AddGroupMemberResponse) {}
+    // Must be group administrator or the authenticated user removing itself from
+    // the group.
+    rpc RemoveGroupMember(RemoveGroupMemberRequest) returns (RemoveGroupMemberResponse) {}
     // Must be group member.
     rpc ListGroupMembers(ListGroupMembersRequest) returns (ListGroupMembersResponse) {}
 
     // Must be group member and author of the note.
-    rpc AddNoteToGroup(AddNoteToGroupRequest) returns (AddNoteToGroupResponse) {}
+    rpc AddGroupNote(AddGroupNoteRequest) returns (AddGroupNoteResponse) {}
     // Must be group member. Can only update `note.title` and `note.folder_id`.
-    rpc UpdateNoteInGroup(UpdateNoteInGroupRequest) returns (UpdateNoteInGroupResponse) {}
+    rpc UpdateGroupNote(UpdateGroupNoteRequest) returns (UpdateGroupNoteResponse) {}
     // Must be group member, author of the note or administrator.
-    rpc RemoveNoteFromGroup(RemoveNoteFromGroupRequest) returns (RemoveNoteFromGroupResponse) {}
+    rpc RemoveGroupNote(RemoveGroupNoteRequest) returns (RemoveGroupNoteResponse) {}
     // Must be group member.
-    rpc ListNotesInGroup(ListNotesInGroupRequest) returns (ListNotesInGroupResponse) {}
+    rpc ListGroupNotes(ListNotesInGroupRequest) returns (ListNotesInGroupResponse) {}
 
     // TODO: Next sprint -- Leave blank.
     rpc CreateFolder(CreateFolderRequest) returns (CreateFolderResponse) {}
-    rpc RemoveFolder(RemoveFolderRequest) returns (RemoveFolderResponse) {}
+    rpc DeleteFolder(DeleteFolderRequest) returns (DeleteFolderResponse) {}
     rpc UpdateFolder(UpdateFolderRequest) returns (UpdateFolderResponse) {}
     rpc ListFolders(ListFoldersRequest) returns (ListFoldersResponse) {}
 }
@@ -109,24 +110,24 @@ message ListGroupMembersResponse {
     repeated GroupMember members = 1;
 }
 
-message AddMemberToGroupRequest {
+message AddGroupMemberRequest {
     string group_id = 1;
     string account_id = 2;
 }
 
-message AddMemberToGroupResponse {
+message AddGroupMemberResponse {
 }
 
-message RemoveMemberFromGroupRequest {
+message RemoveGroupMemberRequest {
     string group_id = 1;
     string account_id = 2;
 }
 
-message RemoveMemberFromGroupResponse {
+message RemoveGroupMemberResponse {
 
 }
 
-message AddNoteToGroupRequest {
+message AddGroupNoteRequest {
     string group_id = 1;
     // ID of the note within the notes-service.
     string note_id = 2;
@@ -137,26 +138,26 @@ message AddNoteToGroupRequest {
     string folder_id = 5;
 }
 
-message AddNoteToGroupResponse {
-    NoteInGroup note = 1;
+message AddGroupNoteResponse {
+    GroupNote note = 1;
 }
 
-message UpdateNoteInGroupRequest {
+message UpdateGroupNoteRequest {
     string group_id = 1;
-    NoteInGroup note = 2;
+    GroupNote note = 2;
     google.protobuf.FieldMask update_mask = 3;
 }
 
-message UpdateNoteInGroupResponse {
-    NoteInGroup note = 1;
+message UpdateGroupNoteResponse {
+    GroupNote note = 1;
 }
 
-message RemoveNoteFromGroupRequest {
+message RemoveGroupNoteRequest {
     string group_id = 1;
     string note_id = 2;
 }
 
-message RemoveNoteFromGroupResponse {
+message RemoveGroupNoteResponse {
 
 }
 
@@ -174,7 +175,7 @@ message ListNotesInGroupRequest {
 }
 
 message ListNotesInGroupResponse {
-    NoteInGroup notes = 1;
+    GroupNote notes = 1;
 }
 
 message CreateFolderRequest {
@@ -185,11 +186,11 @@ message CreateFolderResponse {
     // TODO: Next sprint.
 }
 
-message RemoveFolderRequest {
+message DeleteFolderRequest {
     // TODO: Next sprint.
 }
 
-message RemoveFolderResponse {
+message DeleteFolderResponse {
     // TODO: Next sprint.
 }
 

--- a/noted/accounts/v1/groups.proto
+++ b/noted/accounts/v1/groups.proto
@@ -62,9 +62,9 @@ service GroupsAPI {
     rpc ListNotesInGroup(ListNotesInGroupRequest) returns (ListNotesInGroupResponse) {}
 
     // TODO: Next sprint -- Leave blank.
-    rpc CreateFolder(CreateFolderRequest) returns (CreateFolderReponse) {}
-    rpc RemoveFolder(RemoveFolderRequest) returns (RemoveFolderReponse) {}
-    rpc UpdateFolder(UpdateFolderRequest) returns (UpdateFolderReponse) {}
+    rpc CreateFolder(CreateFolderRequest) returns (CreateFolderResponse) {}
+    rpc RemoveFolder(RemoveFolderRequest) returns (RemoveFolderResponse) {}
+    rpc UpdateFolder(UpdateFolderRequest) returns (UpdateFolderResponse) {}
     rpc ListFolders(ListFoldersRequest) returns (ListFoldersResponse) {}
 }
 
@@ -181,7 +181,7 @@ message CreateFolderRequest {
     // TODO: Next sprint.
 }
 
-message CreateFolderReponse {
+message CreateFolderResponse {
     // TODO: Next sprint.
 }
 
@@ -189,7 +189,7 @@ message RemoveFolderRequest {
     // TODO: Next sprint.
 }
 
-message RemoveFolderReponse {
+message RemoveFolderResponse {
     // TODO: Next sprint.
 }
 
@@ -197,7 +197,7 @@ message UpdateFolderRequest {
     // TODO: Next sprint.
 }
 
-message UpdateFolderReponse {
+message UpdateFolderResponse {
     // TODO: Next sprint.
 }
 

--- a/noted/accounts/v1/groups.proto
+++ b/noted/accounts/v1/groups.proto
@@ -29,6 +29,9 @@ message NoteInGroup {
     string folder_id = 4;
 }
 
+// Creation, read/update, deletion of groups of users.
+// Addition and removal of group members with roles.
+// Management of notes and folders within a group.
 service GroupsAPI {
     // Creates a group with a single administrator member (the authenticated user).
     // Must be authenticated.
@@ -58,7 +61,7 @@ service GroupsAPI {
     // Must be group member.
     rpc ListNotesInGroup(ListNotesInGroupRequest) returns (ListNotesInGroupResponse) {}
 
-    // Next sprint -- Leave blank.
+    // TODO: Next sprint -- Leave blank.
     rpc CreateFolder(CreateFolderRequest) returns (CreateFolderReponse) {}
     rpc RemoveFolder(RemoveFolderRequest) returns (RemoveFolderReponse) {}
     rpc UpdateFolder(UpdateFolderRequest) returns (UpdateFolderReponse) {}
@@ -175,33 +178,33 @@ message ListNotesInGroupResponse {
 }
 
 message CreateFolderRequest {
-    // TODO
+    // TODO: Next sprint.
 }
 
 message CreateFolderReponse {
-    // TODO
+    // TODO: Next sprint.
 }
 
 message RemoveFolderRequest {
-    // TODO
+    // TODO: Next sprint.
 }
 
 message RemoveFolderReponse {
-    // TODO
+    // TODO: Next sprint.
 }
 
 message UpdateFolderRequest {
-    // TODO
+    // TODO: Next sprint.
 }
 
 message UpdateFolderReponse {
-    // TODO
+    // TODO: Next sprint.
 }
 
 message ListFoldersRequest {
-    // TODO
+    // TODO: Next sprint.
 }
 
 message ListFoldersResponse {
-    // TODO
+    // TODO: Next sprint.
 }

--- a/noted/accounts/v1/invites.proto
+++ b/noted/accounts/v1/invites.proto
@@ -1,0 +1,90 @@
+syntax = "proto3";
+
+package noted.accounts.v1;
+
+option go_package = "noted/accounts/v1";
+
+message Invite {
+    string id = 1;
+    string group_id = 2;
+    string sender_account_id = 3;
+    string recipient_account_id = 4;
+}
+
+// Send, accept, deny, revoke and list invitations to groups.
+service InvitesAPI {
+    // The sender defaults to the authenticated user. Must be group member.
+    rpc SendInvite(SendInviteRequest) returns (SendInviteResponse) {}
+    // Must be group administrator or sender or recipient.
+    rpc GetInvite(GetInviteRequest) returns (GetInviteResponse) {}
+    // Must be recipient. Accepting an invitation automatically adds the
+    // recipient to the group and deletes the invite.
+    rpc AcceptInvite(AcceptInviteRequest) returns (AcceptInviteResponse) {}
+    // Must be recipient. Deletes the invitation without making the
+    // recipient join the group.
+    rpc DenyInvite(DenyInviteRequest) returns (DenyInviteResponse) {}
+    // Must be group administrator or sender or recipient.
+    rpc ListInvites(ListInvitesRequest) returns (ListInvitesResponse) {}
+
+    // TODO: Next sprint -- Leave blank.
+    // Must be group administrator or sender. Deletes the invitation without
+    // making the recipient join the group.
+    rpc RevokeInvite(RevokeInviteRequest) returns (RevokeInviteResponse) {}
+}
+
+message SendInviteRequest {
+    string group_id = 1;
+    string recipient_account_id = 2;
+}
+
+message SendInviteResponse {
+    Invite invite = 1;
+}
+
+message GetInviteRequest {
+    string invite_id = 1;
+}
+
+message GetInviteResponse {
+    Invite invite = 1;
+}
+
+message AcceptInviteRequest {
+    string invite_id = 1;
+}
+
+message AcceptInviteResponse {
+
+}
+
+message DenyInviteRequest {
+    string invite_id = 1;
+}
+
+message DenyInviteResponse {
+
+}
+
+message ListInvitesRequest {
+    // (Optional) Returns only invites from sender.
+    string sender_account_id = 1;
+    // (Optional) Returns only invites destined to recipient.
+    string recipient_account_id = 2;
+    // (Optional) Returns only invites for a given group.
+    string group_id = 3;
+    // Defaults to 20.
+    int32 limit = 4;
+    int32 offset = 5; 
+}
+
+message ListInvitesResponse {
+    repeated Invite invites = 1;
+}
+
+message RevokeInviteRequest {
+    // TODO: Next sprint.
+}
+
+message RevokeInviteResponse {
+    // TODO: Next sprint.
+}

--- a/noted/notes/v1/notes.proto
+++ b/noted/notes/v1/notes.proto
@@ -26,10 +26,10 @@ message Block {
         TYPE_HEADING_2 = 2;
         TYPE_HEADING_3 = 3;
         TYPE_PARAGRAPH = 4;
-        TYPE_BULLET_POINT = 7;
-        TYPE_NUMBERED_POINT = 8;
         TYPE_MATH = 5;
         TYPE_CODE = 6;
+        TYPE_BULLET_POINT = 7;
+        TYPE_NUMBERED_POINT = 8;
         TYPE_IMAGE = 9;
     }
     Type type = 2;
@@ -114,7 +114,7 @@ message InsertBlockRequest {
     // Given that a note is an array of blocks, provide the index at
     // which the block shall be inserted.
     uint32 index = 2;
-    //A new block need a note to be attached
+    // A new block need a note to be attached
     uint32 note_id = 3;
 }
 
@@ -138,4 +138,5 @@ message DeleteBlockRequest {
 }
 
 message DeleteBlockResponse {
+
 }


### PR DESCRIPTION
#### Description

Big update to the protorepo in preparation of the fast-forward sprint.

#### Changelog

- [DOCS] Add documentation to all endpoints to explicitely say what the endpoint does.
- [ENHANCEMENT] Change the way members are managed in a group.
- [ENHANCEMENT] Add `accounts.GroupsAPI.RemoveMemberFromGroup` to kick a member from a group.
- [ENHANCEMENT] Add `accounts.GroupsAPI.ListGroupMembers` to list the members of a group.
- [ENHANCEMENT] Add `accounts.GroupsAPI.UpdateNoteInGroup` to change the title / folder of a note in a group.
- [ENHANCEMENT] Add `accounts.GroupsAPI.RemoveNoteFromGroup` to remove a note from a group.
- [ENHANCEMENT] Add `accounts.GroupsAPI.ListNotesInGroup` to list all the notes belonging to a folder/user within a group.
- [ENHANCEMENT] Add `accounts.InvitesAPI` to allow sending, accepting, denying invites.
- [ENHANCEMENT] Add RPCs for next sprints in `accounts.GroupsAPI` and `accounts.InvitesAPI`.
- [BUGFIX] Fixed typo in `accounts.AccountsAPI.ListAccounts`.
