### PR TITLE
MetaNote : Response of ListNote endpoint

### DIFF
--- a/noted/notes/v1/notes.proto
+++ b/noted/notes/v1/notes.proto
@@ -17,6 +17,12 @@ message Note {
     repeated Block blocks = 4;
 }
 
+message MetaNote {
+    string id = 1;
+    string author_id = 2;
+    string title = 3;
+}
+
 message Block {
     string id = 1;
 
@@ -105,16 +111,12 @@ message ListNotesRequest {
 }
 
 message ListNotesResponse {
-    repeated Note notes = 1;
+    repeated MetaNote noteMeta = 1;
 }
 
 message InsertBlockRequest {
-    // The block to append to the note.
     Block block = 1;
-    // Given that a note is an array of blocks, provide the index at
-    // which the block shall be inserted.
     uint32 index = 2;
-    // A new block need a note to be attached
     uint32 note_id = 3;
 }
 

--- a/noted/notes/v1/notes.proto
+++ b/noted/notes/v1/notes.proto
@@ -111,7 +111,7 @@ message ListNotesRequest {
 }
 
 message ListNotesResponse {
-    repeated MetaNote noteMeta = 1;
+    repeated MetaNote note_meta = 1;
 }
 
 message InsertBlockRequest {


### PR DESCRIPTION
#### Description

Created a message `MetaNote` in order to deal with a not without the blocks when you list all the notes.

#### Changelog

`ListNoteResponse` return a `repeated MetaNote`
