### PR TITLE
Fix `AddGroupNoteRequest`

### DIFF
--- a/noted/accounts/v1/groups.proto
+++ b/noted/accounts/v1/groups.proto
@@ -174,8 +174,6 @@ message AddGroupNoteRequest {
     // ID of the note within the notes-service.
     string note_id = 2;
     string title = 3;
-    // Defaults to the authenticated user.
-    string author_account_id = 4;
     // Next sprint -- Leave blank.
     string folder_id = 5;
 }


### PR DESCRIPTION
#### Description

The author of a note within a `GroupNote` should be infered from the author of the `note_id`, it shouldn't be a request parameter.

#### Changelog

- [BUGFIX] Remove `author_account_id` from `AddGroupNoteRequest`. 
