### PR TITLE
CreatedAt and ModifiedAt fields on Note

### DIFF
--- a/noted/notes/v1/notes.proto
+++ b/noted/notes/v1/notes.proto
@@ -5,6 +5,7 @@ package noted.notes.v1;
 option go_package = "noted/notes/v1";
 
 import "google/protobuf/field_mask.proto";
+import "google/protobuf/timestamp.proto";
 
 message Notes {
     repeated Note notes = 1;
@@ -15,6 +16,8 @@ message Note {
     string author_id = 2;
     string title = 3;
     repeated Block blocks = 4;
+    google.protobuf.Timestamp created_at = 5;
+    google.protobuf.Timestamp modified_at = 6;
 }
 
 enum NoteExportFormat {


### PR DESCRIPTION
#### Description

#### Changelog

- [ENHANCEMENT] Add `created_at` and `modified_at` in `Note` message.
