### PR TITLE
Bugfix : wrong type for noteId in InsertBlockRequest

### DIFF
--- a/noted/notes/v1/notes.proto
+++ b/noted/notes/v1/notes.proto
@@ -119,7 +119,7 @@ message ListNotesResponse {
 message InsertBlockRequest {
     Block block = 1;
     uint32 index = 2;
-    uint32 note_id = 3;
+    string note_id = 3;
 }
 
 message InsertBlockResponse {


### PR DESCRIPTION
#### Description

The type of noteid in the InsertBlockRequest message was `uint32` instead of `string`.
The type must be a string because :
 - It's an Id and in all protobuf and service we deal with string
 - We store strings for noteId and blockId in the database 

#### Changelog

A fix needs to be done in notes-service, it's going to be done in https://github.com/noted-eip/notes-service/pull/28 the pull request

- [BUGFIX]
The type of noteid in the InsertBlockRequest message was an uint32
