### PR TITLE
Protobuf for Invites and InviteLinks 

### DIFF
--- a/noted/notes/v1/groups.proto
+++ b/noted/notes/v1/groups.proto
@@ -174,7 +174,11 @@ service GroupsAPI {
     rpc ListConversationMessages(ListConversationMessagesRequest) returns (ListConversationMessagesResponse) {}
 
     // Must be group member. generated_by_account_id defaults to the authenticated user.
-    rpc GenerateInviteLink(GenerateInviteLinkRequest) returns (GenerateInviteLinkResponse) {}
+    rpc GenerateInviteLink(GenerateInviteLinkRequest) returns (GenerateInviteLinkResponse) {
+        option (google.api.http) = {
+            post: "/groups/{group_id}/inviteLinks",
+        };
+    }
     // Must be group member.
     rpc GetInviteLink(GetInviteLinkRequest) returns (GetInviteLinkResponse) {
         option (google.api.http) = {
@@ -182,9 +186,17 @@ service GroupsAPI {
         };
     }
     // Must be group member.
-    rpc RevokeInviteLink(RevokeInviteLinkRequest) returns (RevokeInviteLinkResponse) {}
+    rpc RevokeInviteLink(RevokeInviteLinkRequest) returns (RevokeInviteLinkResponse) {
+        option (google.api.http) = {
+            delete: "/groups/{group_id}/inviteLinks/{invite_link_code}",
+        };
+    }
     // Must not be group member. Makes the authenticated join the group on success.
-    rpc UseInviteLink(UseInviteLinkRequest) returns (UseInviteLinkResponse) {}
+    rpc UseInviteLink(UseInviteLinkRequest) returns (UseInviteLinkResponse) {
+        option (google.api.http) = {
+            post: "/groups/{group_id}/inviteLinks/{invite_link_code}",
+        };
+    }
 
     // The sender defaults to the authenticated user. Must be group member.
     rpc SendInvite(SendInviteRequest) returns (SendInviteResponse) {
@@ -203,8 +215,7 @@ service GroupsAPI {
     // recipient to the group and deletes the invite.
     rpc AcceptInvite(AcceptInviteRequest) returns (AcceptInviteResponse) {
         option (google.api.http) = {
-            post: "/invites/{invite_id}/accept",
-            body: "*",
+            post: "/groups/{group_id}/invites/{invite_id}/accept",
         };
     }
     // Must be recipient. Deletes the invitation without making the
@@ -212,16 +223,20 @@ service GroupsAPI {
     rpc DenyInvite(DenyInviteRequest) returns (DenyInviteResponse) {
         option (google.api.http) = {
             post: "/groups/{group_id}/invites/{invite_id}/deny",
-            body: "*",
         };
     }
     // Must be group administrator or sender. Deletes the invitation without
     // making the recipient join the group.
-    rpc RevokeInvite(RevokeInviteRequest) returns (RevokeInviteResponse) {}
+    rpc RevokeInvite(RevokeInviteRequest) returns (RevokeInviteResponse) {
+        option (google.api.http) = {
+            delete: "/groups/{group_id}/invites/{invite_id}",
+        };
+    }
     // Must be group administrator or sender or recipient.
     rpc ListInvites(ListInvitesRequest) returns (ListInvitesResponse) {
         option (google.api.http) = {
-            get: "/invites",
+            get: "/groups/{group_id}/invites",
+            body: "*"
         };
     }
 }
@@ -461,7 +476,8 @@ message ListInvitesResponse {
 }
 
 message RevokeInviteRequest {
-    string invite_id = 1;
+    string group_id = 1;
+    string invite_id = 2;
 }
 
 message RevokeInviteResponse {


### PR DESCRIPTION
#### Description

Better protobuf for Invites and InviteLinks
There was some inconsistencies on if we used a GroupID + InviteID or juste an InviteID so I just did GroupID + InviteID to differentiate invites on every endpoints.

Basically tried to write every route with more consistency
Tried to use the "body" field as I understand how it should be used

I didn't find the rule that made the use of "REQUIRED" consistent or not on members, so I didn't touch anything on this parts for invites.

#### Changelog

- [ENHANCEMENT] Better route names
- [ENHANCEMENT] Uses GroupID + InviteID everywhere 
- [ENHANCEMENT] Better use of "body" (inchallah) 