### PR TITLE
feat/route for recommendation widgets

### DIFF
--- a/noted/notes/v1/recommendations.proto
+++ b/noted/notes/v1/recommendations.proto
@@ -4,6 +4,7 @@ package noted.notes.v1;
 
 option go_package = "noted/notes/v1";
 
+import "google/api/annotations.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 import "google/api/field_behavior.proto";
 

--- a/noted/notes/v1/recommendations.proto
+++ b/noted/notes/v1/recommendations.proto
@@ -39,32 +39,37 @@ message Widget {
 }
 
 message WebsiteWidget {
-    string title = 1;
-    string url = 2;
+    string title = 1 [(google.api.field_behavior) = REQUIRED];
+    string url = 2 [(google.api.field_behavior) = REQUIRED];
     string description = 3;
 }
 
 message ImageWidget {
-    string title = 1;
-    string url = 2;
+    string title = 1 [(google.api.field_behavior) = REQUIRED];
+    string url = 2 [(google.api.field_behavior) = REQUIRED];
     string caption = 3;
 }
 
 message DefinitionWidget {
-    string word = 1;
+    string word = 1 [(google.api.field_behavior) = REQUIRED];
     string gender = 2;
     string type = 3;
-    string content = 4;
+    string content = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 service RecommendationsAPI {
-    rpc GenerateWidgets(GenerateWidgetsRequest) returns (GenerateWidgetsResponse) {}
+    rpc GenerateWidgets(GenerateWidgetsRequest) returns (GenerateWidgetsResponse) {
+        option (google.api.http) = {
+            get: "/groups/{group_id}/notes/{note_id}/widgets"
+        };
+    }
 }
 
 message GenerateWidgetsRequest {
-    string note_id = 1;
+    string group_id = 1;
+    string note_id = 2;
 }
 
 message GenerateWidgetsResponse {
-    repeated Widget widgets = 1;
+    repeated Widget widgets = 1 [(google.api.field_behavior) = REQUIRED];
 }

--- a/noted/notes/v1/recommendations.proto
+++ b/noted/notes/v1/recommendations.proto
@@ -5,6 +5,7 @@ package noted.notes.v1;
 option go_package = "noted/notes/v1";
 
 import "protoc-gen-openapiv2/options/annotations.proto";
+import "google/api/field_behavior.proto";
 
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
     info: {


### PR DESCRIPTION
#### Description

Add the route url to generate recommendation widgets for a note

#### Changelog

The route `"/groups/{group_id}/notes/{note_id}/widgets"` can be called in order to generate recommendation widgets