### PR TITLE
Limit and Offset type update

### DIFF
--- a/noted/notes/v1/groups.proto
+++ b/noted/notes/v1/groups.proto
@@ -315,8 +315,8 @@ message UpdateGroupResponse {
 
 message ListGroupsRequest {
     string account_id = 1 [(google.api.field_behavior) = REQUIRED];
-    int32 limit = 4;
-    int32 offset = 5;
+    uint32 limit = 4;
+    uint32 offset = 5;
 }
 
 message ListGroupsResponse {
@@ -413,8 +413,8 @@ message DeleteConversationMessageResponse {
 message ListConversationMessagesRequest {
     string group_id = 1;
     string conversation_id = 2;
-    int32 limit = 3;
-    int32 offset = 4;
+    uint32 limit = 3;
+    uint32 offset = 4;
 }
 
 message ListConversationMessagesResponse {
@@ -496,8 +496,8 @@ message ListInvitesRequest {
     string recipient_account_id = 2;
     // Returns only invites for a given group.
     string group_id = 3;
-    int32 limit = 4;
-    int32 offset = 5;
+    uint32 limit = 4;
+    uint32 offset = 5;
 }
 
 message ListInvitesResponse {

--- a/noted/notes/v1/notes.proto
+++ b/noted/notes/v1/notes.proto
@@ -204,8 +204,8 @@ message DeleteNoteResponse {
 message ListNotesRequest {
     string author_account_id = 1;
     string group_id = 2;
-    int32 limit = 3;
-    int32 offset = 4;
+    uint32 limit = 3;
+    uint32 offset = 4;
 }
 
 message ListNotesResponse {


### PR DESCRIPTION
#### Description

The type of `Limit` and `Offsets` was an int32 and it's changed to an uint32.
To prevent the fields to be under 0, because any check was done in the validators in backend.
And theses fields will never be under 0.

#### Changelog

/!\ IMPORTANT /!\
The following endpoints must be modified on the front end :
- `rpc ListNotes(ListNotesRequest) returns (ListNotesResponse)` of route `GET "/groups/{group_id}/notes"`
- `rpc ListGroups(ListGroupsRequest) returns (ListGroupsResponse)` of route `GET "/groups"`
- `rpc ListGroups(ListGroupsRequest) returns (ListGroupsResponse)` of route `GET "/groups"`