### PR TITLE
Add account-id to CreateWorkspaceRequest

### DIFF
--- a/noted/notes/v1/groups.proto
+++ b/noted/notes/v1/groups.proto
@@ -253,6 +253,7 @@ message CreateGroupResponse {
 }
 
 message CreateWorkspaceRequest {
+    string account_id = 1;
 }
 
 message CreateWorkspaceResponse {


### PR DESCRIPTION
#### Description

CreateWorkspace will be called from account-service on CreateAccount, and we can't authenticate the user during the account creation. Right now CreateWorkspace authenticate the user and gets the account-id like this, which is not possible and why I'm adding account id to the request so we can remove the auth from CreateWorkspace

#### Changelog

<!-- Provide a description of the technical changes introduced by your pull request
highlighting any breaking changes -->

- [BUGFIX/ENHANCEMENT] Add account-id to CreateWorkspaceRequest
