### PR TITLE
Fix: Endpoint to give editing permission to a user

### DIFF
--- a/noted/notes/v1/notes.proto
+++ b/noted/notes/v1/notes.proto
@@ -161,6 +161,13 @@ service NotesAPI {
     // Must be account owner.
     rpc OnAccountDelete(OnAccountDeleteRequest) returns (OnAccountDeleteResponse) {}
 
+    rpc GrantNoteEditPermission(GrantNoteEditPermissionRequest) returns (GrantNoteEditPermissionResponse) {
+        option (google.api.http) = {
+            post: "/groups/{group_id}/notes/{note_id}"
+            body: "note"
+        };
+    }
+
 }
 
 message GetNoteRequest {
@@ -256,3 +263,12 @@ message ExportNoteResponse {
 message OnAccountDeleteRequest {}
 
 message OnAccountDeleteResponse {}
+
+
+message GrantNoteEditPermissionRequest {
+    string email = 1; 
+
+}
+message GrantNoteEditPermissionResponse {
+    Note note = 1 [(google.api.field_behavior) = REQUIRED];
+}

--- a/noted/notes/v1/notes.proto
+++ b/noted/notes/v1/notes.proto
@@ -264,9 +264,8 @@ message OnAccountDeleteRequest {}
 
 message OnAccountDeleteResponse {}
 
-
 message GrantNoteEditPermissionRequest {
-    string recipient_id = 1 [(google.api.field_behavior) = REQUIRED];
+    string recipient_account_id = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message GrantNoteEditPermissionResponse {}

--- a/noted/notes/v1/notes.proto
+++ b/noted/notes/v1/notes.proto
@@ -163,7 +163,7 @@ service NotesAPI {
 
     rpc GrantNoteEditPermission(GrantNoteEditPermissionRequest) returns (GrantNoteEditPermissionResponse) {
         option (google.api.http) = {
-            post: "/groups/{group_id}/notes/{note_id}"
+            post: "/groups/{group_id}/notes/{note_id}/permission",
             body: "note"
         };
     }
@@ -266,9 +266,7 @@ message OnAccountDeleteResponse {}
 
 
 message GrantNoteEditPermissionRequest {
-    string email = 1; 
+    string recipient_id = 1 [(google.api.field_behavior) = REQUIRED];
+}
 
-}
-message GrantNoteEditPermissionResponse {
-    Note note = 1 [(google.api.field_behavior) = REQUIRED];
-}
+message GrantNoteEditPermissionResponse {}


### PR DESCRIPTION
#### Description

<!-- Optionally, briefly describe the changes -->

<!-- Include the ID of issue(s) related to this pull request -->

Endpoint to give the permission of editing a note to a new user, so in the end a user can allow another user to edit his own note of which he is the owner

#### Changelog

<!-- Provide a description of the technical changes introduced by your pull request
highlighting any breaking changes -->
- ``GrantNoteEditPermission``
