### PR TITLE
New route to register in db that user is in the mobile beta program

### DIFF
--- a/noted/accounts/v1/accounts.proto
+++ b/noted/accounts/v1/accounts.proto
@@ -168,6 +168,7 @@ service AccountsAPI {
     rpc RegisterUserToMobileBeta(RegisterUserToMobileBetaRequest) returns (RegisterUserToMobileBetaResponse) {
         option (google.api.http) = {
             post: "/beta/mobile",
+            body: "*",
         };
     }
 

--- a/noted/accounts/v1/accounts.proto
+++ b/noted/accounts/v1/accounts.proto
@@ -164,6 +164,14 @@ service AccountsAPI {
         };
     }
 
+    // Registers the user to the mobile application beta.
+    rpc RegisterUserToMobileBeta(RegisterUserToMobileBetaRequest) returns (RegisterUserToMobileBetaResponse) {
+        option (google.api.http) = {
+            post: "/beta/mobile",
+        };
+    }
+
+
 }
 
 message CreateAccountRequest {
@@ -306,3 +314,11 @@ message GetAccountProfilePictureResponse {
     string account_id = 1 [(google.api.field_behavior) = REQUIRED];
     Image image = 2 [(google.api.field_behavior) = REQUIRED];
 }
+
+message RegisterUserForMobileBetaRequest {
+    string account_id = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+message RegisterUserForMobileBetaResponse {
+}
+

--- a/noted/accounts/v1/accounts.proto
+++ b/noted/accounts/v1/accounts.proto
@@ -316,10 +316,10 @@ message GetAccountProfilePictureResponse {
     Image image = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-message RegisterUserForMobileBetaRequest {
+message RegisterUserToMobileBetaRequest {
     string account_id = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
-message RegisterUserForMobileBetaResponse {
+message RegisterUserToMobileBetaResponse {
 }
 

--- a/noted/accounts/v1/accounts.proto
+++ b/noted/accounts/v1/accounts.proto
@@ -38,6 +38,8 @@ message Account {
     string id = 1 [(google.api.field_behavior) = REQUIRED];
     string name = 2 [(google.api.field_behavior) = REQUIRED];
     string email = 3 [(google.api.field_behavior) = REQUIRED];
+
+    bool is_in_mobile_beta = 4; // On long term, should not put this in Account but in a separate database that only stores accounts ids that are in beta (for example) (too lazy too late rn)
 }
 
 message Image {


### PR DESCRIPTION
#### Description

Creates a route that will be used when a user registers to the mobile beta program.
The behavior of the route will be to store in db (boolean for instance) that the users is in the program.

`POST  "/beta/mobile"`
With no body
If you think of a better way feel free to tell me.

#### Changelog

- [ENHANCEMENT] New messages
- [ENHANCEMENT] New route
